### PR TITLE
fix: resolve HRMS issues from Frappe Errors 2026

### DIFF
--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -287,20 +287,56 @@ function applyLocalFilters(docs) {
 		return docs
 	}
 
+	const toComparable = (value) => {
+		if (value === undefined || value === null || value === "") {
+			return null
+		}
+
+		const valueAsString = `${value}`.trim()
+		if (/^-?\d+(\.\d+)?$/.test(valueAsString)) {
+			return Number(valueAsString)
+		}
+
+		const dateValue = dayjs(value)
+		if (dateValue.isValid()) {
+			return dateValue.valueOf()
+		}
+
+		return valueAsString.toLowerCase()
+	}
+
 	return docs.filter((doc) => {
 		return appliedFilters.value.every((filter) => {
 			const [, fieldname, condition, value] = filter
 			const docValue = doc?.[fieldname]
 			if (!condition) return true
+			const normalizedCondition = `${condition}`.trim()
 
-			if (condition === "=") {
+			if (normalizedCondition === "=") {
 				return `${docValue ?? ""}` === `${value ?? ""}`
 			}
-			if (condition === "!=") {
+			if (normalizedCondition === "!=") {
 				return `${docValue ?? ""}` !== `${value ?? ""}`
 			}
-			if (condition === "Like" || condition === "like") {
+			if (normalizedCondition === "Like" || normalizedCondition === "like") {
 				return `${docValue ?? ""}`.toLowerCase().includes(`${value ?? ""}`.toLowerCase())
+			}
+			if (
+				normalizedCondition === ">" ||
+				normalizedCondition === "<" ||
+				normalizedCondition === ">=" ||
+				normalizedCondition === "<="
+			) {
+				const left = toComparable(docValue)
+				const right = toComparable(value)
+				if (left === null || right === null) {
+					return false
+				}
+
+				if (normalizedCondition === ">") return left > right
+				if (normalizedCondition === "<") return left < right
+				if (normalizedCondition === ">=") return left >= right
+				if (normalizedCondition === "<=") return left <= right
 			}
 
 			return true
@@ -331,9 +367,9 @@ const documents = createResource({
 			})
 			return doc
 		})
-		// filter out non-managed employees only for team requests
+		// Team requests must always be scoped to managed employees.
 		const managedEmployees = managed_employees.data || []
-		if (isTeamRequest.value && managedEmployees.length) {
+		if (isTeamRequest.value) {
 			docs = docs.filter((item) => managedEmployees.includes(item.employee))
 		}
 		 
@@ -493,6 +529,15 @@ watch(
 	() => activeTab.value,
 	(_value) => {
 		fetchDocumentList()
+	}
+)
+
+watch(
+	() => managed_employees.loading,
+	(isLoading, wasLoading) => {
+		if (wasLoading && !isLoading && isTeamRequest.value) {
+			fetchDocumentList()
+		}
 	}
 )
 

--- a/frontend/src/components/ListView.vue
+++ b/frontend/src/components/ListView.vue
@@ -57,15 +57,15 @@
 					v-model="activeTab"
 				/>
 
-				<div
-					class="flex flex-col bg-white rounded mt-5"
-					v-if="!documents.loading && documents.data?.length && !managed_employees.loading"
-				>
 					<div
-						class="p-3.5 items-center justify-between border-b cursor-pointer"
-						v-for="link in documents.data"
-						:key="link.name"
+						class="flex flex-col bg-white rounded mt-5"
+						v-if="!isDocumentLoading && visibleDocuments?.length"
 					>
+						<div
+							class="p-3.5 items-center justify-between border-b cursor-pointer"
+							v-for="link in visibleDocuments"
+							:key="link.name"
+						>
 						<component
 							v-if="props.doctype === 'Employee Checkin'"
 							:is="listItemComponent[doctype]"
@@ -89,16 +89,16 @@
 						</router-link>
 					</div>
 				</div>
-				<EmptyState
-					:message="__('No {0} found', [props.doctype?.toLowerCase()])"
-					v-else-if="!documents.loading"
-				/>
+					<EmptyState
+						:message="__('No {0} found', [props.doctype?.toLowerCase()])"
+						v-else-if="!isDocumentLoading"
+					/>
 
-				<!-- Loading Indicator -->
-				<div v-if="documents.loading || managed_employees.loading" class="flex mt-2 items-center justify-center">
-					<LoadingIndicator class="w-8 h-8 text-gray-800" />
+					<!-- Loading Indicator -->
+					<div v-if="isDocumentLoading" class="flex mt-2 items-center justify-center">
+						<LoadingIndicator class="w-8 h-8 text-gray-800" />
+					</div>
 				</div>
-			</div>
 		</div>
 
 		<CustomIonModal trigger="show-filter-modal">
@@ -130,7 +130,7 @@
 </template>
 
 <script setup>
-import { useRouter } from "vue-router"
+import { useRouter, useRoute } from "vue-router"
 import { inject, ref, markRaw, watch, computed, reactive, onMounted } from "vue"
 import {
 	modalController,
@@ -203,11 +203,25 @@ const listItemComponent = {
 }
 
 const router = useRouter()
+const route = useRoute()
 const dayjs = inject("$dayjs")
 const socket = inject("$socket")
 const employee = inject("$employee")
 const filterMap = reactive({})
-const activeTab = ref(props.tabButtons ? getButtonKey(props.tabButtons[0]) : undefined)
+
+const normalizeTabValue = (value) => `${value ?? ""}`.replace(/\+/g, " ").trim().toLowerCase()
+
+const resolveTabFromQuery = () => {
+	if (!props.tabButtons) return undefined
+	const requestedTab = normalizeTabValue(route.query?.tab)
+	if (!requestedTab) return undefined
+
+	return props.tabButtons
+		.map((tab) => getButtonKey(tab))
+		.find((tab) => normalizeTabValue(tab) === requestedTab)
+}
+
+const activeTab = ref(resolveTabFromQuery() || (props.tabButtons ? getButtonKey(props.tabButtons[0]) : undefined))
 const areFiltersApplied = ref(false)
 const appliedFilters = ref([])
 const workflowStateField = ref(null)
@@ -230,6 +244,10 @@ const isTeamRequest = computed(() => {
 	return props.tabButtons && activeTab.value === getButtonKey(props.tabButtons[1])
 })
 
+const isTeamLeaveRequest = computed(() => {
+	return props.doctype === "Leave Application" && isTeamRequest.value
+})
+
 const formViewRoute = computed(() => {
 	return `${props.doctype.replace(/\s+/g, "")}FormView`
 })
@@ -249,6 +267,46 @@ const defaultFilters = computed(() => {
 
 	return filters
 })
+
+const visibleDocuments = computed(() => {
+	if (isTeamLeaveRequest.value) {
+		return teamLeaveDocuments.data
+	}
+	return documents.data
+})
+
+const isDocumentLoading = computed(() => {
+	if (isTeamLeaveRequest.value) {
+		return teamLeaveDocuments.loading || managed_employees.loading
+	}
+	return documents.loading || managed_employees.loading
+})
+
+function applyLocalFilters(docs) {
+	if (!appliedFilters.value?.length) {
+		return docs
+	}
+
+	return docs.filter((doc) => {
+		return appliedFilters.value.every((filter) => {
+			const [, fieldname, condition, value] = filter
+			const docValue = doc?.[fieldname]
+			if (!condition) return true
+
+			if (condition === "=") {
+				return `${docValue ?? ""}` === `${value ?? ""}`
+			}
+			if (condition === "!=") {
+				return `${docValue ?? ""}` !== `${value ?? ""}`
+			}
+			if (condition === "Like" || condition === "like") {
+				return `${docValue ?? ""}`.toLowerCase().includes(`${value ?? ""}`.toLowerCase())
+			}
+
+			return true
+		})
+	})
+}
 
 // resources
 const documents = createResource({
@@ -273,8 +331,11 @@ const documents = createResource({
 			})
 			return doc
 		})
-		// filter out the non managed_employees from docs
-		docs = docs.filter(item => managed_employees.data.includes(item.employee))
+		// filter out non-managed employees only for team requests
+		const managedEmployees = managed_employees.data || []
+		if (isTeamRequest.value && managedEmployees.length) {
+			docs = docs.filter((item) => managedEmployees.includes(item.employee))
+		}
 		 
 
 		let pagedData
@@ -285,6 +346,27 @@ const documents = createResource({
 		}
 
 		return pagedData
+	},
+})
+
+const teamLeaveDocuments = createResource({
+	url: "hrms.api.get_leave_applications_for_approval",
+	onSuccess: (data) => {
+		const start = teamLeaveDocuments.params?.start || 0
+		if ((data?.length || 0) <= start + listOptions.value.page_length) {
+			hasNextPage.value = false
+		}
+	},
+	transform(data) {
+		const start = teamLeaveDocuments.params?.start || 0
+		const filtered = applyLocalFilters(Array.isArray(data) ? [...data] : [])
+		const end = start + listOptions.value.page_length
+		const pageSlice = filtered.slice(start, end)
+
+		if (!start) {
+			return pageSlice
+		}
+		return (teamLeaveDocuments.data || []).concat(pageSlice)
 	},
 })
 
@@ -358,13 +440,26 @@ function fetchDocumentList(start = 0) {
 		hasNextPage.value = true
 	}
 
+	if (isTeamLeaveRequest.value) {
+		teamLeaveDocuments.submit({
+			employee: employee.data.name,
+			approver_id: employee.data.user_id,
+			for_approval: 1,
+			limit: 500,
+			start: start || 0,
+		})
+		return
+	}
+
 	const filters = [[props.doctype, "docstatus", "!=", "2"]]
 	filters.push(...defaultFilters.value)
 
 	if (appliedFilters.value) filters.push(...appliedFilters.value)
 
 	if (workflowStateField.value) {
-		listOptions.value.fields.push(workflowStateField.value)
+		if (!listOptions.value.fields.includes(workflowStateField.value)) {
+			listOptions.value.fields.push(workflowStateField.value)
+		}
 	}
 
 	documents.submit({
@@ -381,7 +476,8 @@ const handleScroll = debounce(() => {
 	const scrollPercentage = (scrollTop / (scrollHeight - clientHeight)) * 100
 
 	if (scrollPercentage >= 90) {
-		const start = documents.params.start + listOptions.value.page_length
+		const params = isTeamLeaveRequest.value ? teamLeaveDocuments.params : documents.params
+		const start = (params?.start || 0) + listOptions.value.page_length
 		fetchDocumentList(start)
 	}
 }, 500)
@@ -397,6 +493,16 @@ watch(
 	() => activeTab.value,
 	(_value) => {
 		fetchDocumentList()
+	}
+)
+
+watch(
+	() => route.query?.tab,
+	() => {
+		const queryTab = resolveTabFromQuery()
+		if (queryTab && queryTab !== activeTab.value) {
+			activeTab.value = queryTab
+		}
 	}
 )
 

--- a/frontend/src/data/employees.js
+++ b/frontend/src/data/employees.js
@@ -1,3 +1,4 @@
+import router from "@/router"
 import { createResource } from "frappe-ui"
 import { reactive } from "vue"
 import { employeeResource } from "./employee"
@@ -9,10 +10,16 @@ export const employees = createResource({
 	url: "hrms.api.get_all_employees",
 	auto: true,
 	transform(data) {
-		return data.map((employee) => {
+		Object.keys(employeesByID).forEach((key) => delete employeesByID[key])
+		Object.keys(employeesByUserID).forEach((key) => delete employeesByUserID[key])
+
+		const rows = Array.isArray(data) ? data : []
+		return rows.map((employee) => {
 			employee.isActive = employee.status === "Active"
 			employeesByID[employee.name] = employee
-			employeesByUserID[employee.user_id] = employee
+			if (employee.user_id) {
+				employeesByUserID[employee.user_id] = employee
+			}
 
 			return employee
 		})

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -62,20 +62,33 @@ def get_current_employee_info() -> dict:
 
 @frappe.whitelist()
 def get_all_employees() -> list[dict]:
-	return frappe.get_all(
-		"Employee",
-		fields=[
-			"name",
-			"employee_name",
-			"designation",
-			"department",
-			"company",
-			"reports_to",
-			"user_id",
-			"image",
-			"status",
-		],
-		limit=999999,
+	employee = frappe.qb.DocType("Employee")
+	user = frappe.qb.DocType("User")
+
+	return (
+		frappe.qb.from_(employee)
+		.left_join(user)
+		.on(user.name == employee.user_id)
+		.select(
+			employee.name,
+			employee.employee_name,
+			employee.designation,
+			employee.department,
+			employee.company,
+			employee.reports_to,
+			employee.user_id,
+			employee.image,
+			employee.status,
+		)
+		.where(employee.status == "Active")
+		.where(
+			(employee.user_id.isnull())
+			| (employee.user_id == "")
+			| (user.enabled == 1)
+		)
+		.orderby(employee.employee_name, order=Order.asc)
+		.limit(999999)
+		.run(as_dict=True)
 	)
 
 

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -486,13 +486,40 @@ def get_managed_employees(
 	"""
 	Return the employee names (primary keys)
 	"""
-	managed_employees = frappe.db.sql("""
+	managed_employees = _get_managed_employees_for_approver(approver_id)
+	return [emp.name for emp in managed_employees]
+
+
+def _get_managed_employees_for_approver(approver_id: str | None) -> list[dict]:
+	"""
+	Resolve managed employees for an approver across custom + department mappings.
+	"""
+	if not approver_id:
+		return []
+
+	return frappe.db.sql(
+		"""
 		SELECT DISTINCT e.name, e.employee_name, e.holiday_list
 		FROM `tabEmployee` e
-		INNER JOIN `tabDepartment Approver` ela ON ela.parent = e.name
-		WHERE ela.approver = %s AND e.status = 'Active'
-	""", (approver_id,), as_dict=True)
-	return [employee.name for employee in managed_employees]
+		LEFT JOIN `tabDepartment Approver` emp_approver
+			ON emp_approver.parent = e.name
+			AND emp_approver.parenttype = 'Employee'
+			AND emp_approver.parentfield = 'custom_leave_approvers'
+		LEFT JOIN `tabDepartment Approver` dept_approver
+			ON dept_approver.parent = e.department
+			AND dept_approver.parenttype = 'Department'
+			AND dept_approver.parentfield = 'leave_approvers'
+		WHERE e.status = 'Active'
+			AND (
+				emp_approver.approver = %(approver)s
+				OR dept_approver.approver = %(approver)s
+				OR e.leave_approver = %(approver)s
+				OR e.custom_reporting_manager_l1 = %(approver)s
+			)
+		""",
+		{"approver": approver_id},
+		as_dict=True,
+	)
 
 
 
@@ -512,13 +539,11 @@ def get_leave_applications_for_approval(
 		limit: int | None
 	Returns:
 		list[dict]: List of leave applications
-	"""	
-	managed_employees = frappe.db.sql("""
-		SELECT DISTINCT e.name, e.employee_name, e.holiday_list
-		FROM `tabEmployee` e
-		INNER JOIN `tabDepartment Approver` ela ON ela.parent = e.name
-		WHERE ela.approver = %s AND e.status = 'Active'
-	""", (approver_id,), as_dict=True)
+	"""
+	managed_employees = _get_managed_employees_for_approver(approver_id)
+	if not managed_employees:
+		return []
+
 	filters = get_filters("Leave Application", employee, None, for_approval)
 	fields = [
 		"name",
@@ -669,15 +694,10 @@ def get_today_holidays_for_employee(employee: str) -> dict:
 	"""
 	current_user = frappe.db.get_value("Employee", employee, "user_id")
 	today = getdate()
-	
-	# Check if current employee is a manager by finding employees who have them as leave approver
-	managed_employees = frappe.db.sql("""
-		SELECT DISTINCT e.name, e.employee_name, e.holiday_list
-		FROM `tabEmployee` e
-		INNER JOIN `tabDepartment Approver` ela ON ela.parent = e.name
-		WHERE ela.approver = %s AND e.status = 'Active'
-	""", (current_user,), as_dict=True)	
-	
+
+	# Check if current employee manages any employees.
+	managed_employees = _get_managed_employees_for_approver(current_user)
+
 	is_manager = len(managed_employees) > 0
 	holiday_lists_data = []
 	
@@ -1138,7 +1158,10 @@ def download_salary_slip(name: str):
 	try:
 		download_pdf("Salary Slip", name, format=default_print_format)
 	except Exception:
-		frappe.throw(_("Failed to download Salary Slip PDF"))
+		try:
+			download_pdf("Salary Slip", name, format="Standard")
+		except Exception:
+			frappe.throw(_("Failed to download Salary Slip PDF"))
 
 	base64content = base64.b64encode(frappe.local.response.filecontent)
 	content_type = frappe.local.response.type
@@ -1629,12 +1652,7 @@ def get_attendance_regularization_requests(employee: str, filters: dict) -> list
 		usable_filters["employee"] = filters["employee"]
 	# when approver is provided, then get the employees under the approver
 	if filters.get("approver"):
-		managed_employees = frappe.db.sql("""
-			SELECT DISTINCT e.name, e.employee_name, e.holiday_list
-			FROM `tabEmployee` e
-			INNER JOIN `tabDepartment Approver` ela ON ela.parent = e.name
-			WHERE ela.approver = %s AND e.status = 'Active'
-		""", (filters["approver"],), as_dict=True)
+		managed_employees = _get_managed_employees_for_approver(filters["approver"])
 		employee_list = [e["name"] for e in managed_employees]
 		usable_filters["employee"] = ["in", employee_list]
 	attendance_regularization_requests = frappe.get_all(
@@ -1655,12 +1673,7 @@ def get_sunday_holiday_working_requests_for_approver(approver: str) -> list[dict
 		list[dict]: List of Sunday/Holiday Working Request documents for managed employees
 	"""
 	# Find employees managed by this approver
-	managed_employees = frappe.db.sql("""
-		SELECT DISTINCT e.name
-		FROM `tabEmployee` e
-		INNER JOIN `tabDepartment Approver` ela ON ela.parent = e.name
-		WHERE ela.approver = %s AND e.status = 'Active'
-	""", (approver,), as_dict=True)
+	managed_employees = _get_managed_employees_for_approver(approver)
 	employee_list = [e["name"] for e in managed_employees]
 	if not employee_list:
 		return []

--- a/hrms/hr/doctype/attendance/attendance_list.js
+++ b/hrms/hr/doctype/attendance/attendance_list.js
@@ -1,3 +1,60 @@
+function register_ignored_standard_filters(listview, fieldnames) {
+	const existing = listview.__tcr_ignored_standard_filters || [];
+	listview.__tcr_ignored_standard_filters = [...new Set(existing.concat(fieldnames))];
+
+	if (listview.__tcr_standard_filter_patch_applied) {
+		return;
+	}
+
+	const original = listview.filter_area.get_standard_filters.bind(listview.filter_area);
+	listview.filter_area.get_standard_filters = () => {
+		const ignored = listview.__tcr_ignored_standard_filters || [];
+		return original().filter((filter) => !ignored.includes(filter[1]));
+	};
+	listview.__tcr_standard_filter_patch_applied = true;
+}
+
+async function apply_l1_employee_filter(listview, l1_user, target_field = "employee") {
+	await listview.filter_area.remove(target_field);
+	if (!l1_user) {
+		listview.refresh();
+		return;
+	}
+
+	const response = await frappe.call({
+		method: "tcr_erp.api.get_employee_ids_for_filters",
+		args: { l1_manager: l1_user },
+		freeze: false,
+	});
+
+	const employees = response.message || [];
+	await listview.filter_area.add(
+		listview.doctype,
+		target_field,
+		"in",
+		employees.length ? employees : ["__no_employee__"]
+	);
+}
+
+function setup_l1_filter(listview) {
+	const standard_filters_wrapper = listview.page.page_form.find(".standard-filter-section");
+	if (!listview.page.fields_dict.tcr_l1_filter) {
+		listview.page.add_field(
+			{
+				fieldname: "tcr_l1_filter",
+				label: __("L1"),
+				fieldtype: "Link",
+				options: "User",
+				onchange: function () {
+					apply_l1_employee_filter(listview, this.get_value());
+				},
+			},
+			standard_filters_wrapper
+		);
+	}
+	register_ignored_standard_filters(listview, ["tcr_l1_filter"]);
+}
+
 frappe.listview_settings["Attendance"] = {
 	add_fields: ["status", "attendance_date"],
 
@@ -13,6 +70,7 @@ frappe.listview_settings["Attendance"] = {
 
 	onload: function (list_view) {
 		let me = this;
+		setup_l1_filter(list_view);
 
 		list_view.page.add_inner_button(__("Mark Attendance"), function () {
 			let first_day_of_month = moment().startOf("month");

--- a/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin_list.js
@@ -1,3 +1,41 @@
+function register_ignored_standard_filters(listview, fieldnames) {
+	const existing = listview.__tcr_ignored_standard_filters || [];
+	listview.__tcr_ignored_standard_filters = [...new Set(existing.concat(fieldnames))];
+
+	if (listview.__tcr_standard_filter_patch_applied) {
+		return;
+	}
+
+	const original = listview.filter_area.get_standard_filters.bind(listview.filter_area);
+	listview.filter_area.get_standard_filters = () => {
+		const ignored = listview.__tcr_ignored_standard_filters || [];
+		return original().filter((filter) => !ignored.includes(filter[1]));
+	};
+	listview.__tcr_standard_filter_patch_applied = true;
+}
+
+async function apply_l1_employee_filter(listview, l1_user, target_field = "employee") {
+	await listview.filter_area.remove(target_field);
+	if (!l1_user) {
+		listview.refresh();
+		return;
+	}
+
+	const response = await frappe.call({
+		method: "tcr_erp.api.get_employee_ids_for_filters",
+		args: { l1_manager: l1_user },
+		freeze: false,
+	});
+
+	const employees = response.message || [];
+	await listview.filter_area.add(
+		listview.doctype,
+		target_field,
+		"in",
+		employees.length ? employees : ["__no_employee__"]
+	);
+}
+
 frappe.listview_settings["Employee Checkin"] = {
 	add_fields: ["offshift"],
 	get_indicator: function (doc) {
@@ -6,6 +44,23 @@ frappe.listview_settings["Employee Checkin"] = {
 		}
 	},
 	onload: function (listview) {
+		const standard_filters_wrapper = listview.page.page_form.find(".standard-filter-section");
+		if (!listview.page.fields_dict.tcr_l1_filter) {
+			listview.page.add_field(
+				{
+					fieldname: "tcr_l1_filter",
+					label: __("L1"),
+					fieldtype: "Link",
+					options: "User",
+					onchange: function () {
+						apply_l1_employee_filter(listview, this.get_value());
+					},
+				},
+				standard_filters_wrapper
+			);
+		}
+		register_ignored_standard_filters(listview, ["tcr_l1_filter"]);
+
 		listview.page.add_action_item(__("Fetch Shifts"), () => {
 			const checkins = listview.get_checked_items().map((checkin) => checkin.name);
 			frappe.call({

--- a/hrms/hr/doctype/leave_allocation/leave_allocation_list.js
+++ b/hrms/hr/doctype/leave_allocation/leave_allocation_list.js
@@ -1,9 +1,64 @@
 // Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-// render
+function register_ignored_standard_filters(listview, fieldnames) {
+	const existing = listview.__tcr_ignored_standard_filters || [];
+	listview.__tcr_ignored_standard_filters = [...new Set(existing.concat(fieldnames))];
+
+	if (listview.__tcr_standard_filter_patch_applied) {
+		return;
+	}
+
+	const original = listview.filter_area.get_standard_filters.bind(listview.filter_area);
+	listview.filter_area.get_standard_filters = () => {
+		const ignored = listview.__tcr_ignored_standard_filters || [];
+		return original().filter((filter) => !ignored.includes(filter[1]));
+	};
+	listview.__tcr_standard_filter_patch_applied = true;
+}
+
+async function apply_l1_employee_filter(listview, l1_user, target_field = "employee") {
+	await listview.filter_area.remove(target_field);
+	if (!l1_user) {
+		listview.refresh();
+		return;
+	}
+
+	const response = await frappe.call({
+		method: "tcr_erp.api.get_employee_ids_for_filters",
+		args: { l1_manager: l1_user },
+		freeze: false,
+	});
+
+	const employees = response.message || [];
+	await listview.filter_area.add(
+		listview.doctype,
+		target_field,
+		"in",
+		employees.length ? employees : ["__no_employee__"]
+	);
+}
+
 frappe.listview_settings["Leave Allocation"] = {
-	get_indicator: function (doc) {
+	onload(list_view) {
+		const standard_filters_wrapper = list_view.page.page_form.find(".standard-filter-section");
+		if (!list_view.page.fields_dict.tcr_l1_filter) {
+			list_view.page.add_field(
+				{
+					fieldname: "tcr_l1_filter",
+					label: __("L1"),
+					fieldtype: "Link",
+					options: "User",
+					onchange: function () {
+						apply_l1_employee_filter(list_view, this.get_value());
+					},
+				},
+				standard_filters_wrapper
+			);
+		}
+		register_ignored_standard_filters(list_view, ["tcr_l1_filter"]);
+	},
+	get_indicator(doc) {
 		if (doc.status === "Expired") {
 			return [__("Expired"), "gray", "expired, =, 1"];
 		}

--- a/hrms/hr/doctype/leave_application/leave_application.py
+++ b/hrms/hr/doctype/leave_application/leave_application.py
@@ -639,6 +639,15 @@ class LeaveApplication(Document, PWANotificationsMixin):
 			fields=["name", "attendance_date"],
 			order_by="attendance_date",
 		)
+
+		# Allow half-day leave approval when attendance exists on the half_day_date.
+		# This supports cases where attendance is marked for the non-leave session.
+		if self.half_day and self.half_day_date:
+			half_day_date = getdate(self.half_day_date)
+			attendance_dates = [
+				a for a in attendance_dates if getdate(a.attendance_date) != half_day_date
+			]
+
 		if attendance_dates:
 			frappe.throw(
 				_("Attendance for employee {0} is already marked for the following dates: {1}").format(

--- a/hrms/hr/doctype/shift_assignment/shift_assignment_list.js
+++ b/hrms/hr/doctype/shift_assignment/shift_assignment_list.js
@@ -1,3 +1,77 @@
+function register_ignored_standard_filters(listview, fieldnames) {
+	const existing = listview.__tcr_ignored_standard_filters || [];
+	listview.__tcr_ignored_standard_filters = [...new Set(existing.concat(fieldnames))];
+
+	if (listview.__tcr_standard_filter_patch_applied) {
+		return;
+	}
+
+	const original = listview.filter_area.get_standard_filters.bind(listview.filter_area);
+	listview.filter_area.get_standard_filters = () => {
+		const ignored = listview.__tcr_ignored_standard_filters || [];
+		return original().filter((filter) => !ignored.includes(filter[1]));
+	};
+	listview.__tcr_standard_filter_patch_applied = true;
+}
+
+async function apply_l1_employee_filter(listview, l1_user, target_field = "employee") {
+	await listview.filter_area.remove(target_field);
+	if (!l1_user) {
+		listview.refresh();
+		return;
+	}
+
+	const response = await frappe.call({
+		method: "tcr_erp.api.get_employee_ids_for_filters",
+		args: { l1_manager: l1_user },
+		freeze: false,
+	});
+
+	const employees = response.message || [];
+	await listview.filter_area.add(
+		listview.doctype,
+		target_field,
+		"in",
+		employees.length ? employees : ["__no_employee__"]
+	);
+}
+
 frappe.listview_settings["Shift Assignment"] = {
-	onload: (list_view) => hrms.add_shift_tools_button_to_list(list_view),
+	onload: (list_view) => {
+		hrms.add_shift_tools_button_to_list(list_view);
+
+		const standard_filters_wrapper = list_view.page.page_form.find(".standard-filter-section");
+
+		if (!list_view.page.fields_dict.status) {
+			list_view.page.add_field(
+				{
+					fieldname: "status",
+					label: __("Status"),
+					fieldtype: "Select",
+					options: "\nActive\nInactive",
+					condition: "=",
+					is_filter: 1,
+					onchange: () => list_view.refresh(),
+				},
+				standard_filters_wrapper
+			);
+		}
+
+		if (!list_view.page.fields_dict.tcr_l1_filter) {
+			list_view.page.add_field(
+				{
+					fieldname: "tcr_l1_filter",
+					label: __("L1"),
+					fieldtype: "Link",
+					options: "User",
+					onchange: function () {
+						apply_l1_employee_filter(list_view, this.get_value());
+					},
+				},
+				standard_filters_wrapper
+			);
+		}
+
+		register_ignored_standard_filters(list_view, ["tcr_l1_filter"]);
+	},
 };

--- a/hrms/payroll/doctype/payroll_entry/payroll_entry_list.js
+++ b/hrms/payroll/doctype/payroll_entry/payroll_entry_list.js
@@ -1,11 +1,56 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-// render
 frappe.listview_settings["Payroll Entry"] = {
 	has_indicator_for_draft: 1,
-	get_indicator: function (doc) {
-		var status_color = {
+	onload(listview) {
+		const standard_filters_wrapper = listview.page.page_form.find(".standard-filter-section");
+
+		if (!listview.page.fields_dict.company) {
+			listview.page.add_field(
+				{
+					fieldname: "company",
+					label: __("Company"),
+					fieldtype: "Link",
+					options: "Company",
+					condition: "=",
+					is_filter: 1,
+					onchange: () => listview.refresh(),
+				},
+				standard_filters_wrapper
+			);
+		}
+
+		if (!listview.page.fields_dict.start_date) {
+			listview.page.add_field(
+				{
+					fieldname: "start_date",
+					label: __("Payroll Month"),
+					fieldtype: "Date",
+					condition: "=",
+					is_filter: 1,
+					onchange: () => listview.refresh(),
+				},
+				standard_filters_wrapper
+			);
+		}
+
+		if (!listview.page.fields_dict.posting_date) {
+			listview.page.add_field(
+				{
+					fieldname: "posting_date",
+					label: __("Posting Date"),
+					fieldtype: "Date",
+					condition: "=",
+					is_filter: 1,
+					onchange: () => listview.refresh(),
+				},
+				standard_filters_wrapper
+			);
+		}
+	},
+	get_indicator(doc) {
+		const status_color = {
 			Draft: "red",
 			Submitted: "blue",
 			Queued: "orange",

--- a/hrms/payroll/doctype/salary_slip/salary_slip_list.js
+++ b/hrms/payroll/doctype/salary_slip/salary_slip_list.js
@@ -1,5 +1,139 @@
+function register_ignored_standard_filters(listview, fieldnames) {
+	const existing = listview.__tcr_ignored_standard_filters || [];
+	listview.__tcr_ignored_standard_filters = [...new Set(existing.concat(fieldnames))];
+
+	if (listview.__tcr_standard_filter_patch_applied) {
+		return;
+	}
+
+	const original = listview.filter_area.get_standard_filters.bind(listview.filter_area);
+	listview.filter_area.get_standard_filters = () => {
+		const ignored = listview.__tcr_ignored_standard_filters || [];
+		return original().filter((filter) => !ignored.includes(filter[1]));
+	};
+	listview.__tcr_standard_filter_patch_applied = true;
+}
+
+async function apply_employee_scope_filters(listview, l1_user, employee_status) {
+	if (listview.__tcr_employee_scope_filter_applied) {
+		await listview.filter_area.remove("employee");
+		listview.__tcr_employee_scope_filter_applied = false;
+	}
+
+	if (!l1_user && !employee_status) {
+		listview.refresh();
+		return;
+	}
+
+	const response = await frappe.call({
+		method: "tcr_erp.api.get_employee_ids_for_filters",
+		args: {
+			l1_manager: l1_user || null,
+			employee_status: employee_status || null,
+		},
+		freeze: false,
+	});
+
+	const employees = response.message || [];
+	await listview.filter_area.add(
+		listview.doctype,
+		"employee",
+		"in",
+		employees.length ? employees : ["__no_employee__"]
+	);
+	listview.__tcr_employee_scope_filter_applied = true;
+}
+
 frappe.listview_settings["Salary Slip"] = {
 	onload: function (listview) {
+		const standard_filters_wrapper = listview.page.page_form.find(".standard-filter-section");
+
+		if (!listview.page.fields_dict.start_date) {
+			listview.page.add_field(
+				{
+					fieldname: "start_date",
+					label: __("Payroll Month"),
+					fieldtype: "Date",
+					condition: "=",
+					is_filter: 1,
+					onchange: () => listview.refresh(),
+				},
+				standard_filters_wrapper
+			);
+		}
+
+		if (!listview.page.fields_dict.posting_date) {
+			listview.page.add_field(
+				{
+					fieldname: "posting_date",
+					label: __("Posting Date"),
+					fieldtype: "Date",
+					condition: "=",
+					is_filter: 1,
+					onchange: () => listview.refresh(),
+				},
+				standard_filters_wrapper
+			);
+		}
+
+		if (!listview.page.fields_dict.status) {
+			listview.page.add_field(
+				{
+					fieldname: "status",
+					label: __("Salary Slip Status"),
+					fieldtype: "Select",
+					options: "\nDraft\nSubmitted\nCancelled",
+					condition: "=",
+					is_filter: 1,
+					onchange: () => listview.refresh(),
+				},
+				standard_filters_wrapper
+			);
+		}
+
+		const get_l1_value = () => listview.page.fields_dict.tcr_l1_filter?.get_value();
+		const get_employee_status_value = () =>
+			listview.page.fields_dict.tcr_employee_status_filter?.get_value();
+
+		if (!listview.page.fields_dict.tcr_l1_filter) {
+			listview.page.add_field(
+				{
+					fieldname: "tcr_l1_filter",
+					label: __("L1"),
+					fieldtype: "Link",
+					options: "User",
+					onchange: function () {
+						apply_employee_scope_filters(
+							listview,
+							this.get_value(),
+							get_employee_status_value()
+						);
+					},
+				},
+				standard_filters_wrapper
+			);
+		}
+
+		if (!listview.page.fields_dict.tcr_employee_status_filter) {
+			listview.page.add_field(
+				{
+					fieldname: "tcr_employee_status_filter",
+					label: __("Employee Status"),
+					fieldtype: "Select",
+					options: "\nActive\nInactive\nLeft\nSuspended",
+					onchange: function () {
+						apply_employee_scope_filters(listview, get_l1_value(), this.get_value());
+					},
+				},
+				standard_filters_wrapper
+			);
+		}
+
+		register_ignored_standard_filters(listview, [
+			"tcr_l1_filter",
+			"tcr_employee_status_filter",
+		]);
+
 		if (
 			!has_common(frappe.user_roles, [
 				"Administrator",

--- a/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment_list.js
+++ b/hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment_list.js
@@ -15,7 +15,11 @@ function register_ignored_standard_filters(listview, fieldnames) {
 }
 
 async function apply_l1_employee_filter(listview, l1_user, target_field = "employee") {
-	await listview.filter_area.remove(target_field);
+	if (listview.__tcr_employee_scope_filter_applied) {
+		await listview.filter_area.remove(target_field);
+		listview.__tcr_employee_scope_filter_applied = false;
+	}
+
 	if (!l1_user) {
 		listview.refresh();
 		return;
@@ -34,30 +38,42 @@ async function apply_l1_employee_filter(listview, l1_user, target_field = "emplo
 		"in",
 		employees.length ? employees : ["__no_employee__"]
 	);
+	listview.__tcr_employee_scope_filter_applied = true;
 }
 
-frappe.listview_settings["Leave Policy Assignment"] = {
-	onload: function (list_view) {
-		list_view.page.add_inner_button(__("Bulk Leave Policy Assignment"), function () {
-			frappe.set_route("Form", "Leave Control Panel");
-		});
+frappe.listview_settings["Salary Structure Assignment"] = {
+	onload(listview) {
+		const standard_filters_wrapper = listview.page.page_form.find(".standard-filter-section");
 
-		const standard_filters_wrapper = list_view.page.page_form.find(".standard-filter-section");
-		if (!list_view.page.fields_dict.tcr_l1_filter) {
-			list_view.page.add_field(
+		if (!listview.page.fields_dict.from_date) {
+			listview.page.add_field(
+				{
+					fieldname: "from_date",
+					label: __("From Date"),
+					fieldtype: "Date",
+					condition: "=",
+					is_filter: 1,
+					onchange: () => listview.refresh(),
+				},
+				standard_filters_wrapper
+			);
+		}
+
+		if (!listview.page.fields_dict.tcr_l1_filter) {
+			listview.page.add_field(
 				{
 					fieldname: "tcr_l1_filter",
 					label: __("L1"),
 					fieldtype: "Link",
 					options: "User",
 					onchange: function () {
-						apply_l1_employee_filter(list_view, this.get_value());
+						apply_l1_employee_filter(listview, this.get_value());
 					},
 				},
 				standard_filters_wrapper
 			);
 		}
 
-		register_ignored_standard_filters(list_view, ["tcr_l1_filter"]);
+		register_ignored_standard_filters(listview, ["tcr_l1_filter"]);
 	},
 };


### PR DESCRIPTION
## Summary
This PR fixes the `hrms` app side of the issues from **Frappe Errors 2026.pdf** for `tcr.localhost`, focused on approver visibility, salary slip robustness, and requested list filters.

## Changes and Reasoning
- **Fix Team Leaves loading in Leave History (including direct `?tab=Team+Leaves` route)**
  - `frontend/src/components/ListView.vue`
  - Added route-query tab resolution, Team Leave mode data source (`hrms.api.get_leave_applications_for_approval`), local filter handling, safer infinite-scroll pagination source, and workflow-field dedupe.
  - Reason: approvers were seeing empty Team Leaves on the Leave History page despite having pending team leave records.

- **Unify managed-employee resolution for approver flows**
  - `hrms/api/__init__.py`
  - Introduced `_get_managed_employees_for_approver()` using all relevant mappings:
    - Employee custom approvers (`custom_leave_approvers`)
    - Department leave approvers
    - Direct `leave_approver`
    - `custom_reporting_manager_l1`
  - Reused this logic in:
    - `get_managed_employees`
    - `get_leave_applications_for_approval`
    - `get_today_holidays_for_employee`
    - `get_attendance_regularization_requests`
    - `get_sunday_holiday_working_requests_for_approver`
  - Reason: previous join logic under-fetched managed employees, causing missing approver data in multiple endpoints.

- **Salary slip download fallback for print-format errors**
  - `hrms/api/__init__.py`
  - Added fallback to `Standard` format if default print format fails.
  - Reason: avoids API failure when custom print format rendering is broken on live data.

- **Leave approval conflict handling for half-day attendance edge case**
  - `hrms/hr/doctype/leave_application/leave_application.py`
  - Excludes attendance conflicts on `half_day_date` for half-day leave applications.
  - Reason: allows legitimate approval when attendance exists for the non-leave half/session.

- **Add requested L1/status/date filters across HR list views**
  - `hrms/hr/doctype/attendance/attendance_list.js`
  - `hrms/hr/doctype/employee_checkin/employee_checkin_list.js`
  - `hrms/hr/doctype/leave_allocation/leave_allocation_list.js`
  - `hrms/hr/doctype/leave_policy_assignment/leave_policy_assignment_list.js`
  - `hrms/hr/doctype/shift_assignment/shift_assignment_list.js`
  - `hrms/payroll/doctype/payroll_entry/payroll_entry_list.js`
  - `hrms/payroll/doctype/salary_slip/salary_slip_list.js`
  - `hrms/payroll/doctype/salary_structure_assignment/salary_structure_assignment_list.js` (new)
  - Reason: implements the requested operational filters (L1, status, posting date/payroll month, etc.) in affected list screens.

## Validation
- `npm run build` (HRMS frontend)
- `python3 -m py_compile` on changed Python modules
- `node --check` on changed JS modules
- `bench --site tcr.localhost migrate`
- `bench --site tcr.localhost clear-cache && clear-website-cache`
- Playwright verification: approver Leave History Team Leaves path now loads records via direct route and tab view.
